### PR TITLE
remove all currently unused/redundant dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,9 @@ version = "0.1.0"
 
 [deps]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
-Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 ModelingToolkit = "5.14"
-Symbolics = "0.1"
 julia = "1.5"
 
 [extras]

--- a/src/NeuronBuilder.jl
+++ b/src/NeuronBuilder.jl
@@ -1,7 +1,6 @@
 module NeuronBuilder
 
-# Write your package code here.
-using ModelingToolkit, OrdinaryDiffEq, Unitful
+using ModelingToolkit 
 
 include("channels.jl")
 include("synapses.jl")
@@ -12,6 +11,5 @@ export NaV, CaS, CaT, H, Ka, KCa, Kdr, Leak
 export Chol, Glut
 export build_channel, build_synapse, build_neuron, build_group
 export add_connection
-
 
 end


### PR DESCRIPTION
Since we aren't (yet) writing custom solvers, OrdinaryDiffEq is a non-essential dependency. A more appropriate place might be [test-specific dependencies](https://pkgdocs.julialang.org/v1/creating-packages/#Test-specific-dependencies-in-Julia-1.2-and-above)

Revise is dev tooling so removed. Symbolics is already [exported by ModelingToolkit](https://github.com/SciML/ModelingToolkit.jl/blob/f253b5198aa2c52d48ba1585b1ec57493faea42d/src/ModelingToolkit.jl#L41), For "correctness", Unitful should be included later on, in a complete unit-checking PR.